### PR TITLE
Fix empty charts in GitHub Pages by handling old benchmark format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,15 +17,3 @@ Original repository (upstream): uselessgoddess/dunes
 Proceed.
 
 Run timestamp: 2025-12-04T06:52:31.418Z
-
----
-
-Issue to solve: https://github.com/uselessgoddess/dunes/issues/32
-Your prepared branch: issue-32-a993175deace
-Your prepared working directory: /tmp/gh-issue-solver-1764836982687
-Your forked repository: konard/uselessgoddess-dunes
-Original repository (upstream): uselessgoddess/dunes
-
-Proceed.
-
-Run timestamp: 2025-12-04T08:29:49.066Z


### PR DESCRIPTION
## Problem

The custom benchmark viewer at https://uselessgoddess.github.io/dunes/dev/bench/custom.html was showing empty charts despite having benchmark data in `data.js`.

## Root Cause

The issue was that old benchmark data (before PR #29) doesn't include tree type tags like `tree=SBT` or `tree=ART` in the `extra` field. The `parseTreeType()` function was returning `'unknown'` for these benchmarks, causing them to be filtered out since `'unknown'` wasn't in the `selectedTrees` set.

Example of old format:
```
"extra": "100 operations in 1673.60 ns/iter"
```

Example of new format:
```
"extra": "tree=SBT ops=100 time=1670.30ns"
```

## Solution

Modified the `parseTreeType()` function in `.github/custom-bench.html` to default to `'SBT'` for benchmarks without tree tags. This is correct because:

1. Old benchmarks predated the ART implementation
2. SBT (Size-Balanced Tree) was the only tree implementation before PR #23
3. Even after ART was added in PR #23, the tree tags weren't added to benchmark output until PR #29

## Changes

- `.github/custom-bench.html`: Changed `parseTreeType()` to return `'SBT'` instead of `'unknown'` for benchmarks without tree tags

## Testing

Created and ran unit tests to verify the fix handles both old and new benchmark formats correctly.

Fixes #32

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)