### PR TITLE
Fix doublets benchmarks and prevent silent pipeline ignore

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,15 +29,3 @@ Original repository (upstream): uselessgoddess/dunes
 Proceed.
 
 Run timestamp: 2025-12-04T14:02:38.031Z
-
----
-
-Issue to solve: https://github.com/uselessgoddess/dunes/issues/40
-Your prepared branch: issue-40-b32f0a529654
-Your prepared working directory: /tmp/gh-issue-solver-1764857685150
-Your forked repository: konard/uselessgoddess-dunes
-Original repository (upstream): uselessgoddess/dunes
-
-Proceed.
-
-Run timestamp: 2025-12-04T14:14:51.904Z


### PR DESCRIPTION
## Summary

This PR fixes the doublets benchmark compilation errors that were preventing the benchmarks from running.

### Issues Fixed

1. **Variable Shadowing Error**: The `bench_search` function had a variable name collision where the `Bencher` parameter `b` was shadowed by a point variable `b`. This caused the compiler to try calling `.iter()` on a `usize` value instead of the `Bencher`, resulting in the error:
   ```
   error[E0599]: the method `iter` exists for type `usize`, but its trait bounds were not satisfied
   ```
   **Fix**: Renamed the point variable from `b` to `target` to avoid shadowing the Bencher parameter.

2. **Deprecated Function Usage**: The benchmarks were using the deprecated `criterion::black_box` function, which triggered multiple deprecation warnings.
   **Fix**: Replaced `criterion::black_box` with `std::hint::black_box` as recommended by the deprecation notice.

### Changes Made

- Updated imports in `crates/doublets/benches/doublets_bench.rs`:
  - Removed `black_box` from criterion imports
  - Added `std::hint::black_box` import
- Fixed variable shadowing in `bench_search` function by renaming point variable from `b` to `target`

### Testing

- ✅ Benchmarks now compile without errors
- ✅ Benchmarks execute successfully with `cargo bench --quick`
- ✅ All CI checks pass
- ⏳ Benchmark workflow running

### Related Issue

Fixes #40

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>