### PR TITLE
Fix doublets benchmarks x-axis labels rendering

### DIFF
--- a/.github/custom-bench.html
+++ b/.github/custom-bench.html
@@ -447,7 +447,11 @@
                                 color: '#8b949e'
                             },
                             ticks: {
-                                color: '#8b949e'
+                                color: '#8b949e',
+                                maxRotation: 45,
+                                minRotation: 45,
+                                autoSkip: true,
+                                maxTicksLimit: 10
                             },
                             grid: {
                                 color: '#30363d'


### PR DESCRIPTION
## Summary

This PR fixes the rendering issue with the doublets benchmarks where x-axis date labels were overlapping and unreadable.

### Changes Made

- Added 45-degree rotation to x-axis date labels in `.github/custom-bench.html:451-452`
- Enabled `autoSkip` to automatically skip labels when they would overlap (line 453)
- Set `maxTicksLimit` to 10 to limit the maximum number of ticks displayed (line 454)

### Technical Details

The fix modifies the Chart.js x-axis tick configuration:
```javascript
ticks: {
    color: '#8b949e',
    maxRotation: 45,        // Rotate labels 45 degrees
    minRotation: 45,        // Minimum rotation angle
    autoSkip: true,         // Skip labels to prevent overlap
    maxTicksLimit: 10       // Maximum 10 ticks on axis
}
```

### Before
![Before - Overlapping labels](https://github.com/user-attachments/assets/47f7705b-56f4-418f-87f1-c09560ea46b7)

### After
The labels are now rotated at 45 degrees, properly spaced, and limited to a maximum of 10 ticks, making them easily readable.

Fixes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)